### PR TITLE
fix(deploy): add site-url to gh-deploy command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,4 @@ jobs:
         run: ./Build.sh
 
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        run: mkdocs gh-deploy --force --site-url https://richard523.github.io/ghpages-CCF-Website


### PR DESCRIPTION
This fixes the broken links on the GitHub Pages deployment by overriding the site_url from mkdocs.yml during the deployment process.