### PR TITLE
fix(deploy): correct gh-pages deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Build site
         run: ./Build.sh
 
+      - name: Configure site_url for deployment
+        run: sed -i 's|site_url: https://carboncopies.org/|site_url: https://richard523.github.io/ghpages-CCF-Website/|' mkdocs.yml
+
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force --site-url https://richard523.github.io/ghpages-CCF-Website
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
Correct the GitHub Pages deployment workflow. The `mkdocs gh-deploy` command does not accept a `--site-url` argument. This commit modifies the workflow to temporarily update the `site_url` in `mkdocs.yml` before deployment.