### PR TITLE
fix(deploy): correct YAML syntax in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,8 @@ jobs:
         run: ./Build.sh
 
       - name: Configure site_url for deployment
-        run: sed -i 's|site_url: https://carboncopies.org/|site_url: https://richard523.github.io/ghpages-CCF-Website/|' mkdocs.yml
+        run: |
+          sed -i 's|site_url: https://carboncopies.org/|site_url: https://richard523.github.io/ghpages-CCF-Website/|' mkdocs.yml
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
Corrects a YAML syntax error in the GitHub Actions workflow file. The `run` command for the `sed` operation contained special characters that caused the parser to fail. The fix uses a YAML block scalar to correctly handle the shell command.